### PR TITLE
feat: implement CLI argument parsing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,79 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "git-logue",
+    version = "0.1.0",
+    about = "A Git history screensaver - watch your code rewrite itself",
+    long_about = "git-logue is a terminal-based screensaver that replays Git commits as if a ghost developer were typing each change by hand. Characters appear, vanish, and transform with natural pacing and syntax highlighting."
+)]
+pub struct Args {
+    #[arg(
+        short,
+        long,
+        value_name = "PATH",
+        help = "Path to Git repository (defaults to current directory)"
+    )]
+    pub path: Option<PathBuf>,
+
+    #[arg(
+        short,
+        long,
+        value_name = "HASH",
+        help = "Replay a specific commit (single-commit mode)"
+    )]
+    pub commit: Option<String>,
+
+    #[arg(
+        short,
+        long,
+        value_name = "MS",
+        default_value = "30",
+        help = "Typing speed in milliseconds per character"
+    )]
+    pub speed: u64,
+}
+
+impl Args {
+    pub fn validate(&self) -> Result<PathBuf> {
+        let repo_path = self
+            .path
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        if !repo_path.exists() {
+            anyhow::bail!("Path does not exist: {}", repo_path.display());
+        }
+
+        let git_dir = repo_path.join(".git");
+        if !git_dir.exists() {
+            anyhow::bail!(
+                "Not a Git repository: {} (or any parent directories)",
+                repo_path.display()
+            );
+        }
+
+        repo_path
+            .canonicalize()
+            .context("Failed to resolve repository path")
+    }
+}
 
 fn main() -> Result<()> {
+    let args = Args::parse();
+    let repo_path = args.validate()?;
+
     println!("git-logue v0.1.0");
+    println!("Repository: {}", repo_path.display());
+    println!("Speed: {}ms per character", args.speed);
+
+    if let Some(commit) = &args.commit {
+        println!("Single-commit mode: {}", commit);
+    } else {
+        println!("Random commit loop mode");
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

Implement command-line interface with clap for git-logue.

## Changes

- Add `Args` struct with clap derive macro:
  - `--path <PATH>`: specify Git repository path (defaults to current directory)
  - `--commit <HASH>`: replay specific commit for single-commit mode
  - `--speed <MS>`: typing speed in milliseconds per character (default: 30)
- Add validation method that:
  - Checks if path exists
  - Verifies path is a Git repository (has .git directory)
  - Canonicalizes repository path
- Add help text and usage examples

## Test plan

- [x] `cargo build` succeeds
- [x] `--help` displays usage information
- [x] Default behavior uses current directory
- [x] Custom options (`--speed`, `--commit`) work correctly
- [x] Validation catches non-existent paths
- [x] Validation catches non-Git directories

## Example usage

```bash
# Default: current directory, random commits, 30ms speed
git-logue

# Specific repository
git-logue --path /path/to/repo

# Single commit mode
git-logue --commit abc123

# Custom typing speed
git-logue --speed 50
```

Resolves #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added command-line argument support to specify repository path, commit reference, and speed parameter.
  * Implemented path validation with enhanced error messages to ensure repository integrity.
  * Enhanced startup output to display repository path, speed setting, and operational mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->