### PR TITLE
feat: implement Git repository and commit loading

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,30 @@ fn print_commit_info(metadata: &git::CommitMetadata) {
 
     if !metadata.changes.is_empty() {
         println!();
+        println!("  File contents:");
+        for change in &metadata.changes {
+            println!("    File: {}", change.path);
+            if change.is_binary {
+                println!("      (binary file)");
+                continue;
+            }
+
+            if let Some(old) = &change.old_content {
+                let lines = old.lines().count();
+                println!("      Old content: {} lines", lines);
+            } else {
+                println!("      Old content: (none - new file)");
+            }
+
+            if let Some(new) = &change.new_content {
+                let lines = new.lines().count();
+                println!("      New content: {} lines", lines);
+            } else {
+                println!("      New content: (none - deleted file)");
+            }
+        }
+
+        println!();
         println!("  Structured changes:");
         for change in &metadata.changes {
             println!("    File: {}", change.path);


### PR DESCRIPTION
## Summary

Implement Git repository operations, commit loading, and comprehensive diff parsing using git2.

This PR combines implementations for:
- **#4**: Git repository and commit loading
- **#5**: Diff parsing and change extraction

## Changes

### Git Module (`src/git.rs`)

**Core structures:**
- `GitRepository`: repository operations
- `CommitMetadata`: commit information with hash, author, date, message, and file changes
- `FileChange`: file-level changes with path, status, binary flag, and structured hunks
- `FileStatus`: A/D/M/R/C/U status indicators
- `DiffHunk`: hunk information with line numbers and structured line changes
- `LineChange`: individual line changes (addition/deletion/context) with content and line numbers

**Features:**
- `open()`: open repository from path
- `get_commit()`: load commit by hash (supports both short and full hashes)
- `random_commit()`: select random non-merge commit
- `extract_changes()`: comprehensive diff parsing with:
  - Line-by-line change extraction
  - Hunk parsing with old/new line tracking
  - Binary file detection
  - Renamed file handling
  - Full diff text preservation

### Main (`src/main.rs`)

- Load repository and display commit metadata
- Support single-commit mode with specific hash
- Support random commit mode with metadata display
- Display file changes with status indicators
- Show structured change information:
  - File count and status summary
  - Hunk statistics (additions/deletions/context)
  - Binary/rename indicators
- Display raw diff output

### Error Handling

- Invalid repository paths
- Non-existent commits
- Invalid commit hashes
- Binary files (graceful skip)

## Test plan

- [x] `cargo build` succeeds
- [x] Random commit selection works
- [x] Specific commit loading works with short hash
- [x] Specific commit loading works with full hash
- [x] Error handling for invalid commit hashes
- [x] Non-merge commits are correctly filtered
- [x] File changes extracted with correct status
- [x] Diff hunks parsed correctly
- [x] Line-by-line changes tracked properly
- [x] Binary files handled gracefully
- [x] Added/modified/deleted files all work

## Example output

```bash
$ cargo run -- --commit 2841866
git-logue v0.1.0
Repository: /home/owner/.ghq/github.com/unhappychoice/git-logue
Speed: 30ms per character

Single-commit mode: 2841866
  Hash:    284186678cbbd2b0b9bbd203a11f3ca1c8f6ef68
  Author:  Yuji Ueki
  Date:    2025-11-08 21:54:58
  Message: feat: implement CLI argument parsing
  ...

  Files changed: 1
    M src/main.rs

  Structured changes:
    File: src/main.rs
      Hunks: 1
        Hunk #1: @@ -1,6 +1,79 @@
          Lines: 80 total (+74 -1 context:5)

  Raw diff:
  diff --git a/src/main.rs b/src/main.rs
  ...
```

Resolves #4
Resolves #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)