### PR TITLE
feat: skip editor animation for deleted and renamed files

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -322,106 +322,104 @@ impl AnimationEngine {
 
         // Process all file changes
         for (index, change) in metadata.changes.iter().enumerate() {
-            // Skip excluded files (lock files and generated files)
-            if change.is_excluded {
-                // Show skip message for excluded files
-                self.steps.push(AnimationStep::Pause {
-                    duration_ms: (self.speed_ms as f64 * OPEN_FILE_PAUSE) as u64,
-                });
-                self.steps.push(AnimationStep::TerminalOutput {
-                    text: format!("📦 {} (skipped - generated file)", change.path),
-                });
-                self.steps.push(AnimationStep::Pause {
-                    duration_ms: (self.speed_ms as f64 * OPEN_CMD_PAUSE) as u64,
-                });
-                continue;
-            }
-
-            // For deleted files, skip editor animation and only run rm + git add
-            if matches!(change.status, FileStatus::Deleted) {
-                self.steps.push(AnimationStep::Pause {
-                    duration_ms: (self.speed_ms as f64 * GIT_ADD_PAUSE) as u64,
-                });
-                self.add_terminal_command(&format!("rm {}", change.path));
-                self.steps.push(AnimationStep::Pause {
-                    duration_ms: (self.speed_ms as f64 * GIT_ADD_CMD_PAUSE) as u64,
-                });
-                self.add_terminal_command(&format!("git add {}", change.path));
-                self.steps.push(AnimationStep::Pause {
-                    duration_ms: (self.speed_ms as f64 * GIT_ADD_CMD_PAUSE) as u64,
-                });
-                continue;
-            }
-
-            // For renamed/moved files, skip editor animation and only run mv + git add
-            if matches!(change.status, FileStatus::Renamed) {
-                self.steps.push(AnimationStep::Pause {
-                    duration_ms: (self.speed_ms as f64 * GIT_ADD_PAUSE) as u64,
-                });
-                if let Some(old_path) = &change.old_path {
-                    self.add_terminal_command(&format!("mv {} {}", old_path, change.path));
+            match (change.is_excluded, &change.status) {
+                // Skip excluded files (lock files and generated files)
+                (true, _) => {
+                    self.steps.push(AnimationStep::Pause {
+                        duration_ms: (self.speed_ms as f64 * OPEN_FILE_PAUSE) as u64,
+                    });
+                    self.steps.push(AnimationStep::TerminalOutput {
+                        text: format!("📦 {} (skipped - generated file)", change.path),
+                    });
+                    self.steps.push(AnimationStep::Pause {
+                        duration_ms: (self.speed_ms as f64 * OPEN_CMD_PAUSE) as u64,
+                    });
+                }
+                // For deleted files, skip editor animation and only run rm + git add
+                (false, FileStatus::Deleted) => {
+                    self.steps.push(AnimationStep::Pause {
+                        duration_ms: (self.speed_ms as f64 * GIT_ADD_PAUSE) as u64,
+                    });
+                    self.add_terminal_command(&format!("rm {}", change.path));
+                    self.steps.push(AnimationStep::Pause {
+                        duration_ms: (self.speed_ms as f64 * GIT_ADD_CMD_PAUSE) as u64,
+                    });
+                    self.add_terminal_command(&format!("git add {}", change.path));
                     self.steps.push(AnimationStep::Pause {
                         duration_ms: (self.speed_ms as f64 * GIT_ADD_CMD_PAUSE) as u64,
                     });
                 }
-                self.add_terminal_command(&format!("git add {}", change.path));
-                self.steps.push(AnimationStep::Pause {
-                    duration_ms: (self.speed_ms as f64 * GIT_ADD_CMD_PAUSE) as u64,
-                });
-                continue;
+                // For renamed/moved files, skip editor animation and only run mv + git add
+                (false, FileStatus::Renamed) => {
+                    self.steps.push(AnimationStep::Pause {
+                        duration_ms: (self.speed_ms as f64 * GIT_ADD_PAUSE) as u64,
+                    });
+                    if let Some(old_path) = &change.old_path {
+                        self.add_terminal_command(&format!("mv {} {}", old_path, change.path));
+                        self.steps.push(AnimationStep::Pause {
+                            duration_ms: (self.speed_ms as f64 * GIT_ADD_CMD_PAUSE) as u64,
+                        });
+                    }
+                    self.add_terminal_command(&format!("git add {}", change.path));
+                    self.steps.push(AnimationStep::Pause {
+                        duration_ms: (self.speed_ms as f64 * GIT_ADD_CMD_PAUSE) as u64,
+                    });
+                }
+                // Normal files (Added, Modified, etc.) - full editor animation
+                (false, _) => {
+                    // Open file in editor
+                    if index == 0 {
+                        self.steps.push(AnimationStep::Pause {
+                            duration_ms: (self.speed_ms as f64 * OPEN_FILE_FIRST_PAUSE) as u64,
+                        });
+                    } else {
+                        self.steps.push(AnimationStep::Pause {
+                            duration_ms: (self.speed_ms as f64 * OPEN_FILE_PAUSE) as u64,
+                        });
+                    }
+                    // Show "Open File..." dialog and type the file path
+                    self.steps.push(AnimationStep::OpenFileDialogStart);
+                    self.steps.push(AnimationStep::Pause {
+                        duration_ms: (self.speed_ms as f64 * 5.0) as u64,
+                    });
+
+                    // Type each character of the file path
+                    for ch in change.path.chars() {
+                        self.steps.push(AnimationStep::DialogTypeChar { ch });
+                    }
+
+                    self.steps.push(AnimationStep::Pause {
+                        duration_ms: (self.speed_ms as f64 * OPEN_CMD_PAUSE) as u64,
+                    });
+
+                    // Add file switch step with both old and new content
+                    let old_content = change.old_content.clone().unwrap_or_default();
+                    let new_content = change.new_content.clone().unwrap_or_default();
+                    self.steps.push(AnimationStep::SwitchFile {
+                        file_index: index,
+                        old_content,
+                        new_content,
+                        path: change.path.clone(),
+                    });
+
+                    // Add pause before starting file animation
+                    self.steps.push(AnimationStep::Pause {
+                        duration_ms: (self.speed_ms as f64 * FILE_SWITCH_PAUSE) as u64,
+                    });
+
+                    // Generate animation steps for this file
+                    self.generate_steps_for_file(change);
+
+                    // Git add this file after editing
+                    self.steps.push(AnimationStep::Pause {
+                        duration_ms: (self.speed_ms as f64 * GIT_ADD_PAUSE) as u64,
+                    });
+                    self.add_terminal_command(&format!("git add {}", change.path));
+                    self.steps.push(AnimationStep::Pause {
+                        duration_ms: (self.speed_ms as f64 * GIT_ADD_CMD_PAUSE) as u64,
+                    });
+                }
             }
-
-            // Open file in editor
-            if index == 0 {
-                self.steps.push(AnimationStep::Pause {
-                    duration_ms: (self.speed_ms as f64 * OPEN_FILE_FIRST_PAUSE) as u64,
-                });
-            } else {
-                self.steps.push(AnimationStep::Pause {
-                    duration_ms: (self.speed_ms as f64 * OPEN_FILE_PAUSE) as u64,
-                });
-            }
-            // Show "Open File..." dialog and type the file path
-            self.steps.push(AnimationStep::OpenFileDialogStart);
-            self.steps.push(AnimationStep::Pause {
-                duration_ms: (self.speed_ms as f64 * 5.0) as u64,
-            });
-
-            // Type each character of the file path
-            for ch in change.path.chars() {
-                self.steps.push(AnimationStep::DialogTypeChar { ch });
-            }
-
-            self.steps.push(AnimationStep::Pause {
-                duration_ms: (self.speed_ms as f64 * OPEN_CMD_PAUSE) as u64,
-            });
-
-            // Add file switch step with both old and new content
-            let old_content = change.old_content.clone().unwrap_or_default();
-            let new_content = change.new_content.clone().unwrap_or_default();
-            self.steps.push(AnimationStep::SwitchFile {
-                file_index: index,
-                old_content,
-                new_content,
-                path: change.path.clone(),
-            });
-
-            // Add pause before starting file animation
-            self.steps.push(AnimationStep::Pause {
-                duration_ms: (self.speed_ms as f64 * FILE_SWITCH_PAUSE) as u64,
-            });
-
-            // Generate animation steps for this file
-            self.generate_steps_for_file(change);
-
-            // Git add this file after editing
-            self.steps.push(AnimationStep::Pause {
-                duration_ms: (self.speed_ms as f64 * GIT_ADD_PAUSE) as u64,
-            });
-            self.add_terminal_command(&format!("git add {}", change.path));
-            self.steps.push(AnimationStep::Pause {
-                duration_ms: (self.speed_ms as f64 * GIT_ADD_CMD_PAUSE) as u64,
-            });
         }
 
         // Git commit


### PR DESCRIPTION
## Summary
- Skip file opening dialog and editor typing animation for deleted and renamed files
- For deleted files, only show `rm` and `git add` commands in terminal
- For renamed/moved files, only show `mv` and `git add` commands in terminal
- Improve animation experience by avoiding unnecessary editor operations for file deletions and renames

## Changes
- Add early return in `load_commit` method for deleted files
- Add early return in `load_commit` method for renamed files
- Import `FileStatus` enum in animation module
- Check file status and skip editor steps when `FileStatus::Deleted` or `FileStatus::Renamed`

## Test plan
- [x] cargo check
- [x] cargo test
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed animation handling for deleted files during commit playback — deletions now show terminal command sequences instead of editor interactions.
  * Fixed animation handling for renamed files — renames now show move/add command sequences and skip editor-opening animations.

* **Improvements**
  * Preserves existing editor-open animations for edits and additions; adds short pauses around command animations for clearer playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->