### PR TITLE
feat: add exclusion for large files and snapshots

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -328,8 +328,12 @@ impl AnimationEngine {
                     self.steps.push(AnimationStep::Pause {
                         duration_ms: (self.speed_ms as f64 * OPEN_FILE_PAUSE) as u64,
                     });
+                    let reason = change
+                        .exclusion_reason
+                        .as_deref()
+                        .unwrap_or("excluded file");
                     self.steps.push(AnimationStep::TerminalOutput {
-                        text: format!("📦 {} (skipped - generated file)", change.path),
+                        text: format!("📦 {} (skipped - {})", change.path, reason),
                     });
                     self.steps.push(AnimationStep::Pause {
                         duration_ms: (self.speed_ms as f64 * OPEN_CMD_PAUSE) as u64,


### PR DESCRIPTION
## Summary
- Add snapshot files to exclusion patterns to prevent animation freeze
- Limit animation to files with ≤2000 changed lines
- Display specific exclusion reasons in terminal output

## Problem
The application would freeze when encountering commits with very large files (e.g., test snapshots with 750k+ lines of changes). This caused excessive memory consumption (~1.5GB) and made the application unusable.

## Solution
1. **Snapshot File Exclusion**: Added `.snap` and `__snapshots__` to excluded patterns
2. **Change Line Limit**: Files with more than 2000 changed lines are automatically skipped
   - Memory consumption: ~4MB per file (acceptable)
   - Animation time: ~1.3 hours (reasonable for screensaver mode)
3. **Exclusion Reason Display**: Show why files are skipped (e.g., "too many changes (756953 lines)")

## Memory Estimation
- Per changed line: ~2KB (includes InsertLine, InsertChar for each character, Pause)
- 2000 lines: ~4MB ✅
- 750k lines: ~1.5GB ❌ (previous issue)

## Test Plan
- [x] All existing tests pass
- [x] New test for snapshot file exclusion
- [x] Tested with problematic commit (684ba2b with 756k deletions)
- [x] Application no longer freezes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skipped files now show a specific exclusion reason in the output for clearer feedback.
  * Snapshot and lock/generated file patterns are recognized and excluded automatically.
  * Files with very large changes are auto-excluded when they exceed a configured change threshold.

* **Tests**
  * Added tests to verify snapshot and exclusion behaviors and retained coverage for lock/minified exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->