### PR TITLE
feat: improve FileTree scroll, unicode width support, and full-width background

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -220,7 +220,7 @@ impl<'a> UI<'a> {
 
         // Update file tree data if needed
         if let Some(metadata) = self.engine.current_metadata() {
-            let content_width = left_layout[0].width.saturating_sub(4) as usize;
+            let content_width = left_layout[0].width as usize;
             self.file_tree.set_commit_metadata(
                 metadata,
                 self.engine.current_file_index,


### PR DESCRIPTION
## Summary

This PR extends FileTree background color to full width for all lines and fixes rendering issues caused by the ratatui wrap bug.

## Changes

### Full-width Background
- Remove Block left/right padding (changed from 2 to 0)
- Add manual padding (2 spaces) to the beginning of each line
- Extend background color to full width for:
  - Directory headers
  - Selected file lines
  - Normal file lines
- Fix content width calculation to match actual rendered width

### Bug Fix
- Prevents Editor background color from bleeding into FileTree area
- This is a workaround for the ratatui 0.29 wrap bug where ghost characters and background colors from other panes can appear when using Paragraph with wrap
- The issue is fixed in ratatui 0.30.0-beta but we're working around it by ensuring every line is fully filled with the correct background color

## Technical Details

The root cause was that ratatui's wrap feature with differential rendering could leave stale background colors when content doesn't change. By filling every line to the full width with the appropriate background color, we prevent any other pane's background from showing through.

## Test Plan

- [x] cargo check
- [x] cargo test  
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo fmt
- [x] Manual testing: verified background extends to full width
- [x] Manual testing: confirmed no Editor background bleeding into FileTree

🤖 Generated with [Claude Code](https://claude.com/claude-code)