### PR TITLE
fix: use vendored OpenSSL and libgit2 for cross-platform builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.4+3.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +885,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "ISC"
 repository = "https://github.com/unhappychoice/gitlogue"
 
 [dependencies]
-git2 = "0.19"
+git2 = { version = "0.19", features = ["vendored-openssl", "vendored-libgit2"] }
 ratatui = "0.29"
 crossterm = "0.28"
 tree-sitter = "0.25"


### PR DESCRIPTION
## Summary

Fix release workflow build failures by enabling vendored features for git2 dependency.

## Problem

The release workflow was failing on macOS runners with:
```
error: failed to run custom build command for `openssl-sys v0.9.111`
Could not find directory of OpenSSL installation
```

## Solution

Enable `vendored-openssl` and `vendored-libgit2` features for the git2 dependency in Cargo.toml. This ensures:
- OpenSSL is built from source and bundled with the binary
- libgit2 is built from source and bundled with the binary
- No dependency on system-installed OpenSSL/libgit2
- Reproducible builds across all platforms

## Changes

```toml
git2 = { version = "0.19", features = ["vendored-openssl", "vendored-libgit2"] }
```

## Test Plan

- [x] Local build successful
- [ ] Verify GitHub Actions build succeeds for all targets:
  - macOS (Intel/ARM)
  - Linux (x64/ARM64)
  - Windows

## Reference

This approach is used by gittype: https://github.com/unhappychoice/gittype/blob/main/Cargo.toml#L58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to enable vendored OpenSSL and libgit2, improving installation compatibility and reducing external system dependency requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->