### PR TITLE
fix: reduce package size for crates.io publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,23 @@ description = "A Git history screensaver - watch your code rewrite itself"
 license = "ISC"
 repository = "https://github.com/unhappychoice/gitlogue"
 
+exclude = [
+    "*.png",
+    "*.gif",
+    "*.jpg",
+    "*.jpeg",
+    "*.mp4",
+    "docs/",
+    "examples/",
+    ".github/",
+    "Formula/",
+    "LICENSE-THIRD-PARTY",
+    "about.toml",
+    "about.hbs",
+    "generate_changelog.sh",
+    "install.sh",
+]
+
 [dependencies]
 git2 = { version = "0.19", features = ["vendored-openssl", "vendored-libgit2"] }
 ratatui = "0.29"


### PR DESCRIPTION
## Summary

Fix crates.io publish error by reducing package size below 10MB limit.

## Problem

Release workflow failed with:
```
error: failed to publish gitlogue v0.0.3 to registry at https://crates.io
the remote server responded with an error (status 413 Payload Too Large): max upload size is: 10485760
```

## Solution

Add `exclude` list to Cargo.toml to exclude unnecessary files:

### Excluded Files
- **Images**: `*.png`, `*.gif`, `*.jpg`, `*.jpeg`, `*.mp4`
- **Documentation**: `docs/` directory
- **Examples**: `examples/` directory  
- **CI/CD**: `.github/` directory
- **Distribution**: `Formula/`, `install.sh`, `generate_changelog.sh`
- **License tracking**: `LICENSE-THIRD-PARTY`, `about.toml`, `about.hbs`

### Result
- Package file count: **93 → ~72 files**
- Only source code, README, LICENSE, and CHANGELOG included
- Package size significantly reduced

## Test Plan

- [x] Verified with `cargo package --list --allow-dirty`
- [x] Confirmed essential files remain (src/, LICENSE, README, CHANGELOG)
- [ ] After merge: Verify crates.io publish succeeds

## Reference

Similar approach used by gittype: https://github.com/unhappychoice/gittype/blob/main/Cargo.toml#L15-L23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to exclude non-source asset files and directories from distribution, reducing package size.
  * Expanded project dependencies with additional grammar support, runtime utilities, and serialization/utility libraries for enhanced internal capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->