### PR TITLE
fix: include LICENSE-THIRD-PARTY in package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ exclude = [
     "examples/",
     ".github/",
     "Formula/",
-    "LICENSE-THIRD-PARTY",
     "about.toml",
     "about.hbs",
     "generate_changelog.sh",


### PR DESCRIPTION
## Summary

Fix cargo package build error by including LICENSE-THIRD-PARTY file in the published package.

## Problem

Cargo package verification failed with:
```
error: couldn't read `src/../LICENSE-THIRD-PARTY`: No such file or directory (os error 2)
   --> src/main.rs:121:24
    |
121 |         println!("{}", include_str!("../LICENSE-THIRD-PARTY"));
```

## Root Cause

`LICENSE-THIRD-PARTY` was excluded in Cargo.toml `exclude` list, but the code in `src/main.rs:121` uses `include_str!("../LICENSE-THIRD-PARTY")` to embed the file content for the `--license` flag feature.

## Solution

Remove `LICENSE-THIRD-PARTY` from the `exclude` list in Cargo.toml.

## Impact

- Package file count: **72 → 73 files**
- LICENSE-THIRD-PARTY file size: ~150KB (4,436 lines)
- Total package size: Still well under the 10MB crates.io limit
- `gitlogue --license` command will work correctly

## Test Plan

- [x] Verified with `cargo package --list --allow-dirty`
- [x] Confirmed LICENSE-THIRD-PARTY is now included
- [ ] After merge: Verify `cargo package` succeeds
- [ ] After merge: Verify crates.io publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to include third-party license information in distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->