### PR TITLE
chore: add dependabot configuration for Cargo dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 25
+    reviewers:
+      - "unhappychoice"
+    assignees:
+      - "unhappychoice"


### PR DESCRIPTION
## Summary
- Add Dependabot configuration for automated Cargo dependency updates
- Configure daily checks with a limit of 25 open PRs
- Auto-assign reviews to unhappychoice

## Test plan
- [ ] Verify the configuration file is valid
- [ ] Wait for Dependabot to create PRs (if dependencies need updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->