### PR TITLE
fix: use ~/.config for config path on all platforms

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -94,8 +94,9 @@ impl Config {
     }
 
     pub fn config_path() -> Result<PathBuf> {
-        let config_dir = dirs::config_dir()
-            .context("Failed to determine config directory")?
+        let config_dir = dirs::home_dir()
+            .context("Failed to determine home directory")?
+            .join(".config")
             .join("gitlogue");
 
         fs::create_dir_all(&config_dir).with_context(|| {
@@ -110,8 +111,9 @@ impl Config {
 
     #[allow(dead_code)]
     pub fn themes_dir() -> Result<PathBuf> {
-        let config_dir = dirs::config_dir()
-            .context("Failed to determine config directory")?
+        let config_dir = dirs::home_dir()
+            .context("Failed to determine home directory")?
+            .join(".config")
             .join("gitlogue")
             .join("themes");
 


### PR DESCRIPTION
## Summary
- Change config path from `dirs::config_dir()` to `dirs::home_dir().join(".config")`
- Ensures `~/.config/gitlogue/config.toml` is used on all platforms (macOS, Linux, Windows)
- Previously macOS used `~/Library/Application Support` which was inconsistent with documentation

## Test plan
- [ ] Verify config file is created at `~/.config/gitlogue/config.toml` on macOS
- [ ] Verify config file is created at `~/.config/gitlogue/config.toml` on Linux
- [ ] Verify existing configs at old locations still need manual migration (or add migration logic)

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration and theme file storage location. These files are now stored in the `.config/gitlogue` directory within your home directory instead of the system configuration directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->