### PR TITLE
Add bun.lock to ignored files list

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -19,6 +19,7 @@ const EXCLUDED_FILES: &[&str] = &[
     "package-lock.json",
     "pnpm-lock.yaml",
     "bun.lock",
+    "bun.lockb",
     // Rust
     "Cargo.lock",
     // Ruby


### PR DESCRIPTION
Add's `bun.lock` to ignored files (https://bun.sh)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Diff animations now ignore an additional Bun lock file variant to reduce clutter in code-change displays and make diffs easier to review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->