### PR TITLE
feat: add MODULE.bazel.lock to excluded files

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -45,6 +45,8 @@ const EXCLUDED_FILES: &[&str] = &[
     "buildscript-gradle.lockfile",
     // Scala
     "build.sbt.lock",
+    // Bazel
+    "MODULE.bazel.lock",
 ];
 
 // File patterns to exclude from diff animation
@@ -710,6 +712,8 @@ mod tests {
         assert!(should_exclude_file("buildscript-gradle.lockfile"));
         // Scala
         assert!(should_exclude_file("build.sbt.lock"));
+        // Bazel
+        assert!(should_exclude_file("MODULE.bazel.lock"));
     }
 
     #[test]


### PR DESCRIPTION
close: #83

## Summary
- Added Bazel's `MODULE.bazel.lock` to the lock file exclusion list
- Added corresponding test case for the new exclusion

## Details
This change ensures that Bazel's lock file (`MODULE.bazel.lock`) is filtered from diff animations, consistent with other build system lock files already in the exclusion list.

## Test plan
- ✅ All existing tests pass
- ✅ New test case added and passing
- ✅ `cargo check` passed
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` passed
- ✅ `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced file exclusion handling to prevent build system lock files from being tracked in the repository.

* **Tests**
  * Added test coverage to verify the file exclusion mechanism functions correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->