### PR TITLE
Use last supported LTS for glibc version in Linux builds & use arm runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,12 +94,12 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.version.outputs.new_version }}
-          release_name: Release ${{ steps.version.outputs.new_version }}
+          name: Release ${{ steps.version.outputs.new_version }}
           body: ${{ steps.extract_notes.outputs.RELEASE_NOTES }}
           draft: false
           prerelease: false


### PR DESCRIPTION
Using the ubuntu-latest for builds causes a glibc issue in older ubuntu versions. To support current active Ubuntu versions, I propose building on Ubuntu 22.04, many software does that :)

Also, you can use partner images `ubuntu-22.04-arm` as GitHub officially support them. https://github.com/actions/partner-runner-images. You'll no longer need to install `gcc-aarch64-linux-gnu` specifically on amd64 runner.

Last create-release was archived 4 years ago, I switched to the most famous alternative action-gh-release (see https://github.com/actions/create-release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized release and build workflows to improve deployment efficiency and compatibility across supported platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->