### PR TITLE
fix: update fzf and VHS examples for better compatibility

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -437,11 +437,11 @@ Type "cd my-project"
 Enter
 Sleep 500ms
 
-Type "gitlogue --theme dracula --commit abc123 && echo 'Finished'"
+Type "gitlogue --theme dracula --commit abc123; echo FINISHED"
 Enter
 
-# Wait for gitlogue to complete
-Wait /Finished/
+# Wait for FINISHED to appear anywhere on screen (120s timeout for large commits)
+Wait+Screen@120s /FINISHED/
 Sleep 1s
 ```
 
@@ -461,12 +461,14 @@ Add this function to your `~/.bashrc` or `~/.zshrc`:
 ```bash
 # Browse commits and launch gitlogue on selection
 glf() {
-  git log --oneline --color=always "$@" | \
+  local commit
+  commit=$(git log --oneline --color=always "$@" | \
     fzf --ansi \
         --no-sort \
         --preview 'git show --stat --color=always {1}' \
-        --preview-window=right:60% \
-        --bind 'enter:become(gitlogue --commit {1})'
+        --preview-window=right:60% | \
+    awk '{print $1}')
+  [ -n "$commit" ] && gitlogue --commit "$commit"
 }
 ```
 
@@ -499,9 +501,8 @@ gitlogue-menu() {
       gitlogue
       ;;
     "Specific commit")
-      git log --oneline | \
-        fzf --prompt="Select commit> " \
-            --bind 'enter:become(gitlogue --commit {1})'
+      local commit=$(git log --oneline | fzf --prompt="Select commit> " | awk '{print $1}')
+      [ -n "$commit" ] && gitlogue --commit "$commit"
       ;;
     "By author")
       local author=$(git log --format='%an' | sort -u | fzf --prompt="Select author> ")


### PR DESCRIPTION
## Summary
- Replace fzf `become` action with variable capture approach to fix "Failed to initialize input reader" errors on macOS
- Fix VHS tape example to use semicolon for reliable FINISHED marker output

## Changes
- **fzf integration**: The `become` action can cause terminal initialization issues when launching TUI apps on some systems. Changed to capture commit hash in a variable first, then launch gitlogue.
- **VHS example**: Use `;` instead of `&&` to ensure the FINISHED marker is always printed (even if gitlogue exits with non-zero status).

## Test plan
- [ ] Test `glf` function on macOS
- [ ] Test VHS tape recording

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated usage examples with refined command sequences and streamlined commit selection workflows to enhance clarity and improve usability guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->