### PR TITLE
Update README to reflect new brew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ curl -fsSL https://raw.githubusercontent.com/unhappychoice/gitlogue/main/install
 ### Using Homebrew
 
 ```bash
-brew install unhappychoice/tap/gitlogue
+brew install gitlogue
 ```
 
 ### Using Cargo


### PR DESCRIPTION
This project can now be directly installed via `brew install gitlogue` instead of via the external `unhappychoice/tap/gitlogue`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Homebrew installation instructions for a more streamlined setup process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->