### PR TITLE
feat: add uv.lock to the excluded files

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -41,6 +41,7 @@ const EXCLUDED_FILES: &[&str] = &[
     // Python
     "poetry.lock",
     "Pipfile.lock",
+    "uv.lock",
     // PHP
     "composer.lock",
     // Go
@@ -1099,6 +1100,7 @@ mod tests {
         // Python
         assert!(should_exclude_file("poetry.lock"));
         assert!(should_exclude_file("Pipfile.lock"));
+        assert!(should_exclude_file("uv.lock"));
         // PHP
         assert!(should_exclude_file("composer.lock"));
         // Go


### PR DESCRIPTION
Add `uv.lock` to the excluded files.

This change has been tested on a sample project and works as expected. If any additional adjustments are needed, please let me know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated lock file exclusion rules and corresponding test assertions to ensure consistent handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->