### PR TITLE
feat(syntax): support tree-sitter language injections

### DIFF
--- a/examples/test_highlighter.rs
+++ b/examples/test_highlighter.rs
@@ -54,4 +54,46 @@ fn main() {
             i, span.start, span.end, span.token_type, text
         );
     }
+
+    let astro_code = r#"---
+const name = "world";
+---
+<h1>Hello {name}</h1>
+<style>
+  h1 { color: red; }
+</style>
+"#;
+    println!("\n=== Testing Astro highlighting ===");
+    let mut astro_highlighter = gitlogue::syntax::Highlighter::new();
+    let astro_success = astro_highlighter.set_language_from_path("test.astro");
+    println!("Language set: {}", astro_success);
+    let astro_highlights = astro_highlighter.highlight(astro_code);
+    println!("Number of highlights: {}", astro_highlights.len());
+    for (i, span) in astro_highlights.iter().enumerate().take(25) {
+        let text = &astro_code[span.start..span.end];
+        println!(
+            "{}: [{}-{}] {:?} = '{}'",
+            i, span.start, span.end, span.token_type, text
+        );
+    }
+
+    let html_code = r#"<!DOCTYPE html>
+<html>
+<head><style>body { color: blue; }</style></head>
+<body><script>const x = 1;</script></body>
+</html>
+"#;
+    println!("\n=== Testing HTML highlighting ===");
+    let mut html_highlighter = gitlogue::syntax::Highlighter::new();
+    let html_success = html_highlighter.set_language_from_path("test.html");
+    println!("Language set: {}", html_success);
+    let html_highlights = html_highlighter.highlight(html_code);
+    println!("Number of highlights: {}", html_highlights.len());
+    for (i, span) in html_highlights.iter().enumerate().take(25) {
+        let text = &html_code[span.start..span.end];
+        println!(
+            "{}: [{}-{}] {:?} = '{}'",
+            i, span.start, span.end, span.token_type, text
+        );
+    }
 }

--- a/src/syntax/languages/astro.rs
+++ b/src/syntax/languages/astro.rs
@@ -3,3 +3,5 @@ pub fn language() -> tree_sitter::Language {
 }
 
 pub const HIGHLIGHT_QUERY: &str = tree_sitter_astro_next::HIGHLIGHTS_QUERY;
+
+pub const INJECTION_QUERY: &str = tree_sitter_astro_next::INJECTIONS_QUERY;

--- a/src/syntax/languages/html.rs
+++ b/src/syntax/languages/html.rs
@@ -3,3 +3,5 @@ pub fn language() -> tree_sitter::Language {
 }
 
 pub const HIGHLIGHT_QUERY: &str = tree_sitter_html::HIGHLIGHTS_QUERY;
+
+pub const INJECTION_QUERY: &str = tree_sitter_html::INJECTIONS_QUERY;

--- a/src/syntax/languages/markdown.rs
+++ b/src/syntax/languages/markdown.rs
@@ -4,6 +4,8 @@ pub fn language() -> tree_sitter::Language {
 
 // Custom highlight query for better visibility
 // Based on tree_sitter_md::HIGHLIGHT_QUERY_BLOCK with improved colors
+pub const INJECTION_QUERY: &str = tree_sitter_md::INJECTION_QUERY_BLOCK;
+
 pub const HIGHLIGHT_QUERY: &str = r#"
 ;From nvim-treesitter/nvim-treesitter
 (atx_heading (inline) @text.title)

--- a/src/syntax/languages/mod.rs
+++ b/src/syntax/languages/mod.rs
@@ -32,42 +32,212 @@ pub mod zig;
 use std::path::Path;
 use tree_sitter::Language;
 
-pub fn get_language(path: &Path) -> Option<(Language, &'static str)> {
-    let extension = path.extension()?.to_str()?;
+#[derive(Clone)]
+pub struct LanguageSupport {
+    pub language: Language,
+    pub highlight_query: &'static str,
+    pub injection_query: Option<&'static str>,
+}
 
-    match extension {
-        "astro" => Some((astro::language(), astro::HIGHLIGHT_QUERY)),
-        "sh" | "bash" | "zsh" => Some((bash::language(), bash::HIGHLIGHT_QUERY)),
-        // C++ before C to handle .h files (can be either)
-        "cpp" | "cc" | "cxx" | "c++" | "C" | "CPP" | "hpp" | "hh" | "hxx" | "h++" | "H" | "HPP"
-        | "tcc" | "inl" => Some((cpp::language(), cpp::HIGHLIGHT_QUERY)),
-        "c" | "h" => Some((c::language(), c::HIGHLIGHT_QUERY)),
-        "clj" | "cljs" | "cljc" | "edn" => Some((clojure::language(), clojure::HIGHLIGHT_QUERY)),
-        "cs" | "csx" => Some((csharp::language(), csharp::HIGHLIGHT_QUERY)),
-        "css" | "scss" | "sass" => Some((css::language(), css::HIGHLIGHT_QUERY)),
-        "dart" => Some((dart::language(), dart::HIGHLIGHT_QUERY)),
-        "ex" | "exs" => Some((elixir::language(), elixir::HIGHLIGHT_QUERY)),
-        "erl" | "hrl" | "es" | "escript" => Some((erlang::language(), erlang::HIGHLIGHT_QUERY)),
-        "go" => Some((go_lang::language(), go_lang::HIGHLIGHT_QUERY)),
-        "hs" | "lhs" => Some((haskell::language(), haskell::HIGHLIGHT_QUERY)),
-        "html" | "htm" => Some((html::language(), html::HIGHLIGHT_QUERY)),
-        "java" => Some((java::language(), java::HIGHLIGHT_QUERY)),
-        "js" | "jsx" | "mjs" | "cjs" => Some((javascript::language(), javascript::HIGHLIGHT_QUERY)),
-        "json" | "jsonc" => Some((json::language(), json::HIGHLIGHT_QUERY)),
-        "kt" | "kts" => Some((kotlin::language(), kotlin::HIGHLIGHT_QUERY)),
-        "lua" => Some((lua::language(), lua::HIGHLIGHT_QUERY)),
-        "md" | "markdown" => Some((markdown::language(), markdown::HIGHLIGHT_QUERY)),
-        "php" | "php3" | "php4" | "php5" | "phtml" => Some((php::language(), php::HIGHLIGHT_QUERY)),
-        "py" | "pyw" => Some((python::language(), python::HIGHLIGHT_QUERY)),
-        "rb" | "rbw" | "rake" | "gemspec" => Some((ruby::language(), ruby::HIGHLIGHT_QUERY)),
-        "rs" => Some((rust::language(), rust::HIGHLIGHT_QUERY)),
-        "scala" | "sc" | "sbt" => Some((scala::language(), scala::HIGHLIGHT_QUERY)),
-        "svelte" => Some((svelte::language(), svelte::HIGHLIGHT_QUERY)),
-        "swift" => Some((swift::language(), swift::HIGHLIGHT_QUERY)),
-        "ts" | "tsx" | "mts" | "cts" => Some((typescript::language(), typescript::HIGHLIGHT_QUERY)),
-        "xml" | "svg" | "xsl" | "xslt" => Some((xml::language(), xml::HIGHLIGHT_QUERY)),
-        "yaml" | "yml" => Some((yaml::language(), yaml::HIGHLIGHT_QUERY)),
-        "zig" => Some((zig::language(), zig::HIGHLIGHT_QUERY)),
+pub fn get_language(path: &Path) -> Option<LanguageSupport> {
+    let extension = path.extension()?.to_str()?;
+    by_name(extension)
+}
+
+pub fn get_language_by_name(name: &str) -> Option<LanguageSupport> {
+    by_name(name.trim().trim_start_matches('.'))
+}
+
+fn by_name(raw: &str) -> Option<LanguageSupport> {
+    let canonical = canonicalize(raw)?;
+    match canonical {
+        "astro" => Some(LanguageSupport {
+            language: astro::language(),
+            highlight_query: astro::HIGHLIGHT_QUERY,
+            injection_query: Some(astro::INJECTION_QUERY),
+        }),
+        "bash" => Some(LanguageSupport {
+            language: bash::language(),
+            highlight_query: bash::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "c" => Some(LanguageSupport {
+            language: c::language(),
+            highlight_query: c::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "clojure" => Some(LanguageSupport {
+            language: clojure::language(),
+            highlight_query: clojure::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "cpp" => Some(LanguageSupport {
+            language: cpp::language(),
+            highlight_query: cpp::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "csharp" => Some(LanguageSupport {
+            language: csharp::language(),
+            highlight_query: csharp::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "css" => Some(LanguageSupport {
+            language: css::language(),
+            highlight_query: css::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "dart" => Some(LanguageSupport {
+            language: dart::language(),
+            highlight_query: dart::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "elixir" => Some(LanguageSupport {
+            language: elixir::language(),
+            highlight_query: elixir::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "erlang" => Some(LanguageSupport {
+            language: erlang::language(),
+            highlight_query: erlang::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "go" => Some(LanguageSupport {
+            language: go_lang::language(),
+            highlight_query: go_lang::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "haskell" => Some(LanguageSupport {
+            language: haskell::language(),
+            highlight_query: haskell::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "html" => Some(LanguageSupport {
+            language: html::language(),
+            highlight_query: html::HIGHLIGHT_QUERY,
+            injection_query: Some(html::INJECTION_QUERY),
+        }),
+        "java" => Some(LanguageSupport {
+            language: java::language(),
+            highlight_query: java::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "javascript" => Some(LanguageSupport {
+            language: javascript::language(),
+            highlight_query: javascript::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "json" => Some(LanguageSupport {
+            language: json::language(),
+            highlight_query: json::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "kotlin" => Some(LanguageSupport {
+            language: kotlin::language(),
+            highlight_query: kotlin::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "lua" => Some(LanguageSupport {
+            language: lua::language(),
+            highlight_query: lua::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "markdown" => Some(LanguageSupport {
+            language: markdown::language(),
+            highlight_query: markdown::HIGHLIGHT_QUERY,
+            injection_query: Some(markdown::INJECTION_QUERY),
+        }),
+        "php" => Some(LanguageSupport {
+            language: php::language(),
+            highlight_query: php::HIGHLIGHT_QUERY,
+            injection_query: Some(php::INJECTION_QUERY),
+        }),
+        "python" => Some(LanguageSupport {
+            language: python::language(),
+            highlight_query: python::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "ruby" => Some(LanguageSupport {
+            language: ruby::language(),
+            highlight_query: ruby::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "rust" => Some(LanguageSupport {
+            language: rust::language(),
+            highlight_query: rust::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "scala" => Some(LanguageSupport {
+            language: scala::language(),
+            highlight_query: scala::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "svelte" => Some(LanguageSupport {
+            language: svelte::language(),
+            highlight_query: svelte::HIGHLIGHT_QUERY,
+            injection_query: Some(svelte::INJECTION_QUERY),
+        }),
+        "swift" => Some(LanguageSupport {
+            language: swift::language(),
+            highlight_query: swift::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "typescript" => Some(LanguageSupport {
+            language: typescript::language(),
+            highlight_query: typescript::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "xml" => Some(LanguageSupport {
+            language: xml::language(),
+            highlight_query: xml::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "yaml" => Some(LanguageSupport {
+            language: yaml::language(),
+            highlight_query: yaml::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        "zig" => Some(LanguageSupport {
+            language: zig::language(),
+            highlight_query: zig::HIGHLIGHT_QUERY,
+            injection_query: None,
+        }),
+        _ => None,
+    }
+}
+
+fn canonicalize(raw: &str) -> Option<&'static str> {
+    let lower = raw.to_ascii_lowercase();
+    match lower.as_str() {
+        "astro" => Some("astro"),
+        "sh" | "bash" | "zsh" | "shell" => Some("bash"),
+        "cpp" | "cc" | "cxx" | "c++" | "hpp" | "hh" | "hxx" | "h++" | "tcc" | "inl" => Some("cpp"),
+        "c" | "h" => Some("c"),
+        "clj" | "cljs" | "cljc" | "edn" | "clojure" => Some("clojure"),
+        "cs" | "csx" | "csharp" | "c#" => Some("csharp"),
+        "css" | "scss" | "sass" | "postcss" | "less" => Some("css"),
+        "dart" => Some("dart"),
+        "ex" | "exs" | "elixir" => Some("elixir"),
+        "erl" | "hrl" | "es" | "escript" | "erlang" => Some("erlang"),
+        "go" | "golang" => Some("go"),
+        "hs" | "lhs" | "haskell" => Some("haskell"),
+        "html" | "htm" => Some("html"),
+        "java" => Some("java"),
+        "js" | "jsx" | "mjs" | "cjs" | "javascript" => Some("javascript"),
+        "json" | "jsonc" | "json5" => Some("json"),
+        "kt" | "kts" | "kotlin" => Some("kotlin"),
+        "lua" => Some("lua"),
+        "md" | "markdown" => Some("markdown"),
+        "php" | "php3" | "php4" | "php5" | "phtml" => Some("php"),
+        "py" | "pyw" | "python" => Some("python"),
+        "rb" | "rbw" | "rake" | "gemspec" | "ruby" => Some("ruby"),
+        "rs" | "rust" => Some("rust"),
+        "scala" | "sc" | "sbt" => Some("scala"),
+        "svelte" => Some("svelte"),
+        "swift" => Some("swift"),
+        "ts" | "tsx" | "mts" | "cts" | "typescript" => Some("typescript"),
+        "xml" | "svg" | "xsl" | "xslt" => Some("xml"),
+        "yaml" | "yml" => Some("yaml"),
+        "zig" => Some("zig"),
         _ => None,
     }
 }

--- a/src/syntax/languages/mod.rs
+++ b/src/syntax/languages/mod.rs
@@ -214,7 +214,7 @@ fn canonicalize(raw: &str) -> Option<&'static str> {
         "c" | "h" => Some("c"),
         "clj" | "cljs" | "cljc" | "edn" | "clojure" => Some("clojure"),
         "cs" | "csx" | "csharp" | "c#" => Some("csharp"),
-        "css" | "scss" | "sass" | "postcss" | "less" => Some("css"),
+        "css" | "scss" | "postcss" | "less" => Some("css"),
         "dart" => Some("dart"),
         "ex" | "exs" | "elixir" => Some("elixir"),
         "erl" | "hrl" | "es" | "escript" | "erlang" => Some("erlang"),

--- a/src/syntax/languages/php.rs
+++ b/src/syntax/languages/php.rs
@@ -3,3 +3,5 @@ pub fn language() -> tree_sitter::Language {
 }
 
 pub const HIGHLIGHT_QUERY: &str = tree_sitter_php::HIGHLIGHTS_QUERY;
+
+pub const INJECTION_QUERY: &str = tree_sitter_php::INJECTIONS_QUERY;

--- a/src/syntax/languages/svelte.rs
+++ b/src/syntax/languages/svelte.rs
@@ -3,3 +3,5 @@ pub fn language() -> tree_sitter::Language {
 }
 
 pub const HIGHLIGHT_QUERY: &str = tree_sitter_svelte_ng::HIGHLIGHTS_QUERY;
+
+pub const INJECTION_QUERY: &str = tree_sitter_svelte_ng::INJECTIONS_QUERY;

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -2,11 +2,14 @@ pub mod languages;
 
 use crate::theme::Theme;
 use ratatui::style::Color;
+use std::ops::Range;
 use std::path::Path;
 use streaming_iterator::StreamingIterator;
-use tree_sitter::{Language, Parser, Query, QueryCursor};
+use tree_sitter::{Language, Parser, Query, QueryCursor, QueryMatch, Tree};
 
-pub use languages::get_language;
+pub use languages::{get_language, get_language_by_name, LanguageSupport};
+
+const MAX_INJECTION_DEPTH: u8 = 4;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenType {
@@ -55,28 +58,41 @@ pub struct HighlightSpan {
 pub struct Highlighter {
     parser: Parser,
     language: Option<Language>,
-    query: Option<Query>,
-    query_source: Option<String>,
-    cached_tree: Option<tree_sitter::Tree>,
+    highlight_query: Option<Query>,
+    highlight_query_source: Option<String>,
+    injection_query: Option<Query>,
+    injection_query_source: Option<String>,
+    cached_tree: Option<Tree>,
     cached_source: String,
 }
 
 impl Clone for Highlighter {
     fn clone(&self) -> Self {
-        let mut new_parser = Parser::new();
-        let query = if let (Some(ref lang), Some(ref source)) = (&self.language, &self.query_source)
-        {
-            let _ = new_parser.set_language(lang);
-            Query::new(lang, source).ok()
-        } else {
-            None
-        };
+        let mut parser = Parser::new();
+        let (highlight_query, injection_query) = self
+            .language
+            .as_ref()
+            .map(|lang| {
+                let _ = parser.set_language(lang);
+                let hq = self
+                    .highlight_query_source
+                    .as_ref()
+                    .and_then(|src| Query::new(lang, src).ok());
+                let iq = self
+                    .injection_query_source
+                    .as_ref()
+                    .and_then(|src| Query::new(lang, src).ok());
+                (hq, iq)
+            })
+            .unwrap_or((None, None));
 
         Self {
-            parser: new_parser,
+            parser,
             language: self.language.clone(),
-            query,
-            query_source: self.query_source.clone(),
+            highlight_query,
+            highlight_query_source: self.highlight_query_source.clone(),
+            injection_query,
+            injection_query_source: self.injection_query_source.clone(),
             cached_tree: None,
             cached_source: String::new(),
         }
@@ -88,119 +104,71 @@ impl Highlighter {
         Self {
             parser: Parser::new(),
             language: None,
-            query: None,
-            query_source: None,
+            highlight_query: None,
+            highlight_query_source: None,
+            injection_query: None,
+            injection_query_source: None,
             cached_tree: None,
             cached_source: String::new(),
         }
     }
 
     pub fn set_language_from_path(&mut self, path: &str) -> bool {
-        if let Some((language, query_source)) = get_language(Path::new(path)) {
-            if self.parser.set_language(&language).is_ok() {
-                if let Ok(query) = Query::new(&language, query_source) {
-                    self.language = Some(language);
-                    self.query = Some(query);
-                    self.query_source = Some(query_source.to_string());
-                    self.cached_tree = None;
-                    self.cached_source = String::new();
-                    return true;
-                }
+        self.clear_language();
+        let Some(support) = get_language(Path::new(path)) else {
+            return false;
+        };
+        if self.parser.set_language(&support.language).is_err() {
+            return false;
+        }
+        let Ok(highlight_query) = Query::new(&support.language, support.highlight_query) else {
+            return false;
+        };
+        self.highlight_query = Some(highlight_query);
+        self.highlight_query_source = Some(support.highlight_query.to_string());
+        if let Some(src) = support.injection_query {
+            if let Ok(query) = Query::new(&support.language, src) {
+                self.injection_query = Some(query);
+                self.injection_query_source = Some(src.to_string());
             }
         }
-        // Language not supported - clear previous language settings
+        self.language = Some(support.language);
+        true
+    }
+
+    fn clear_language(&mut self) {
         self.language = None;
-        self.query = None;
-        self.query_source = None;
+        self.highlight_query = None;
+        self.highlight_query_source = None;
+        self.injection_query = None;
+        self.injection_query_source = None;
         self.cached_tree = None;
-        self.cached_source = String::new();
-        false
+        self.cached_source.clear();
     }
 
     pub fn highlight(&mut self, source: &str) -> Vec<HighlightSpan> {
-        let mut spans = Vec::new();
-
-        let Some(query) = &self.query else {
-            return spans;
+        let Some(highlight_query) = &self.highlight_query else {
+            return Vec::new();
         };
 
-        // Use incremental parsing only if source hasn't changed
         let old_tree = if self.cached_source == source {
             self.cached_tree.as_ref()
         } else {
             None
         };
-
         let Some(tree) = self.parser.parse(source, old_tree) else {
-            return spans;
+            return Vec::new();
         };
-
-        // Cache the tree and source for next incremental parse (clone needed because matches borrows tree)
         self.cached_tree = Some(tree.clone());
         self.cached_source = source.to_string();
 
-        let mut cursor = QueryCursor::new();
-        let mut matches = cursor.matches(query, tree.root_node(), source.as_bytes());
-
-        while let Some(query_match) = matches.next() {
-            for capture in query_match.captures {
-                let node = capture.node;
-                let capture_name = &query.capture_names()[capture.index as usize];
-
-                // Handle dotted capture names like "keyword.function" -> "keyword"
-                let base_name = capture_name.split('.').next().unwrap_or(capture_name);
-
-                let token_type = match base_name {
-                    "annotation" | "attribute" | "decorator" => TokenType::Keyword,
-                    "boolean" => TokenType::Constant,
-                    "character" => TokenType::String,
-                    "class" | "constructor" | "enum" | "interface" | "struct" | "trait" => {
-                        TokenType::Type
-                    }
-                    "comment" => TokenType::Comment,
-                    "conditional" | "exception" | "include" | "repeat" | "storageclass" => {
-                        TokenType::Keyword
-                    }
-                    "constant" => TokenType::Constant,
-                    "delimiter" => TokenType::Punctuation,
-                    "escape" => TokenType::Operator,
-                    "field" => TokenType::Property,
-                    "float" => TokenType::Number,
-                    "function" => TokenType::Function,
-                    "identifier" => TokenType::Variable,
-                    "keyword" => TokenType::Keyword,
-                    "label" => TokenType::Label,
-                    "macro" | "method" => TokenType::Function,
-                    "module" | "namespace" => TokenType::Type,
-                    "number" => TokenType::Number,
-                    "operator" => TokenType::Operator,
-                    "parameter" => TokenType::Parameter,
-                    "property" => TokenType::Property,
-                    "punctuation" => TokenType::Punctuation,
-                    "regexp" => TokenType::String,
-                    "special" => TokenType::Operator,
-                    "string" => TokenType::String,
-                    "tag" => TokenType::Type,
-                    "text" => TokenType::String,
-                    "type" => TokenType::Type,
-                    "variable" => TokenType::Variable,
-                    // Skip internal/special markers
-                    "__name__" | "_name" | "_op" | "_type" | "embedded" | "none" | "spell" => {
-                        continue
-                    }
-                    _ => continue,
-                };
-
-                spans.push(HighlightSpan {
-                    start: node.start_byte(),
-                    end: node.end_byte(),
-                    token_type,
-                });
-            }
-        }
-
-        spans.sort_by_key(|span| span.start);
-        spans
+        let outer = collect_spans(highlight_query, &tree, source);
+        let injections = self
+            .injection_query
+            .as_ref()
+            .map(|q| gather_injections(q, &tree, source, 0))
+            .unwrap_or_default();
+        merge_injection_spans(outer, injections)
     }
 }
 
@@ -208,4 +176,182 @@ impl Default for Highlighter {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn collect_spans(query: &Query, tree: &Tree, source: &str) -> Vec<HighlightSpan> {
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(query, tree.root_node(), source.as_bytes());
+    let mut spans = Vec::new();
+    while let Some(m) = matches.next() {
+        for capture in m.captures {
+            let capture_name = &query.capture_names()[capture.index as usize];
+            let Some(token_type) = capture_name_to_token(capture_name) else {
+                continue;
+            };
+            spans.push(HighlightSpan {
+                start: capture.node.start_byte(),
+                end: capture.node.end_byte(),
+                token_type,
+            });
+        }
+    }
+    spans.sort_by_key(|span| span.start);
+    spans
+}
+
+fn capture_name_to_token(capture_name: &str) -> Option<TokenType> {
+    let base = capture_name.split('.').next().unwrap_or(capture_name);
+    let token = match base {
+        "annotation" | "attribute" | "decorator" => TokenType::Keyword,
+        "boolean" => TokenType::Constant,
+        "character" => TokenType::String,
+        "class" | "constructor" | "enum" | "interface" | "struct" | "trait" => TokenType::Type,
+        "comment" => TokenType::Comment,
+        "conditional" | "exception" | "include" | "repeat" | "storageclass" => TokenType::Keyword,
+        "constant" => TokenType::Constant,
+        "delimiter" => TokenType::Punctuation,
+        "escape" => TokenType::Operator,
+        "field" => TokenType::Property,
+        "float" => TokenType::Number,
+        "function" => TokenType::Function,
+        "identifier" => TokenType::Variable,
+        "keyword" => TokenType::Keyword,
+        "label" => TokenType::Label,
+        "macro" | "method" => TokenType::Function,
+        "module" | "namespace" => TokenType::Type,
+        "number" => TokenType::Number,
+        "operator" => TokenType::Operator,
+        "parameter" => TokenType::Parameter,
+        "property" => TokenType::Property,
+        "punctuation" => TokenType::Punctuation,
+        "regexp" => TokenType::String,
+        "special" => TokenType::Operator,
+        "string" => TokenType::String,
+        "tag" => TokenType::Type,
+        "text" => TokenType::String,
+        "type" => TokenType::Type,
+        "variable" => TokenType::Variable,
+        _ => return None,
+    };
+    Some(token)
+}
+
+fn gather_injections(
+    query: &Query,
+    tree: &Tree,
+    source: &str,
+    depth: u8,
+) -> Vec<(Range<usize>, Vec<HighlightSpan>)> {
+    if depth >= MAX_INJECTION_DEPTH {
+        return Vec::new();
+    }
+    let content_index = capture_index(query, "injection.content");
+    let Some(content_index) = content_index else {
+        return Vec::new();
+    };
+
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(query, tree.root_node(), source.as_bytes());
+    let mut out = Vec::new();
+    while let Some(m) = matches.next() {
+        let Some(lang_name) = resolve_injection_language(query, m, source) else {
+            continue;
+        };
+        let Some(support) = get_language_by_name(&lang_name) else {
+            continue;
+        };
+        for capture in m.captures {
+            if capture.index != content_index {
+                continue;
+            }
+            let range = capture.node.byte_range();
+            if range.start >= range.end || range.end > source.len() {
+                continue;
+            }
+            let slice = &source[range.clone()];
+            let inner = highlight_slice(&support, slice, range.start, depth + 1);
+            out.push((range, inner));
+        }
+    }
+    out
+}
+
+fn capture_index(query: &Query, name: &str) -> Option<u32> {
+    query
+        .capture_names()
+        .iter()
+        .position(|n| *n == name)
+        .map(|i| i as u32)
+}
+
+fn resolve_injection_language(query: &Query, m: &QueryMatch, source: &str) -> Option<String> {
+    for prop in query.property_settings(m.pattern_index) {
+        if prop.key.as_ref() == "injection.language" {
+            if let Some(value) = &prop.value {
+                return Some(value.to_ascii_lowercase());
+            }
+        }
+    }
+    let lang_idx = capture_index(query, "injection.language")?;
+    m.captures
+        .iter()
+        .find(|c| c.index == lang_idx)
+        .and_then(|c| {
+            let text = source.get(c.node.byte_range())?.trim();
+            let cleaned = text.trim_matches(|ch: char| ch == '"' || ch == '\'' || ch == '`');
+            (!cleaned.is_empty()).then(|| cleaned.to_ascii_lowercase())
+        })
+}
+
+fn highlight_slice(
+    support: &LanguageSupport,
+    source: &str,
+    base_offset: usize,
+    depth: u8,
+) -> Vec<HighlightSpan> {
+    let mut parser = Parser::new();
+    if parser.set_language(&support.language).is_err() {
+        return Vec::new();
+    }
+    let Ok(highlight_query) = Query::new(&support.language, support.highlight_query) else {
+        return Vec::new();
+    };
+    let Some(tree) = parser.parse(source, None) else {
+        return Vec::new();
+    };
+
+    let outer = collect_spans(&highlight_query, &tree, source);
+    let injections = support
+        .injection_query
+        .and_then(|src| Query::new(&support.language, src).ok())
+        .map(|q| gather_injections(&q, &tree, source, depth))
+        .unwrap_or_default();
+    let merged = merge_injection_spans(outer, injections);
+    merged
+        .into_iter()
+        .map(|s| HighlightSpan {
+            start: s.start + base_offset,
+            end: s.end + base_offset,
+            token_type: s.token_type,
+        })
+        .collect()
+}
+
+fn merge_injection_spans(
+    outer: Vec<HighlightSpan>,
+    injections: Vec<(Range<usize>, Vec<HighlightSpan>)>,
+) -> Vec<HighlightSpan> {
+    if injections.is_empty() {
+        return outer;
+    }
+    let ranges: Vec<Range<usize>> = injections.iter().map(|(r, _)| r.clone()).collect();
+    let mut merged: Vec<HighlightSpan> = outer
+        .into_iter()
+        .filter(|s| !ranges.iter().any(|r| s.start < r.end && r.start < s.end))
+        .collect();
+    for (_, inner) in injections {
+        merged.extend(inner);
+    }
+    merged.sort_by_key(|span| span.start);
+    merged
 }

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -299,7 +299,11 @@ fn resolve_injection_language(query: &Query, m: &QueryMatch, source: &str) -> Op
         .and_then(|c| {
             let text = source.get(c.node.byte_range())?.trim();
             let cleaned = text.trim_matches(|ch: char| ch == '"' || ch == '\'' || ch == '`');
-            (!cleaned.is_empty()).then(|| cleaned.to_ascii_lowercase())
+            let first = cleaned
+                .split(|ch: char| ch.is_whitespace() || ch == ',' || ch == '{')
+                .next()?
+                .trim();
+            (!first.is_empty()).then(|| first.to_ascii_lowercase())
         })
 }
 


### PR DESCRIPTION
## Summary
- Resolve `@injection.content` / `@injection.language` captures, re-parse those ranges with the target language, and merge spans into the outer highlight — per approach 2 in #191.
- Wire `INJECTION_QUERY` for Astro, Svelte, HTML, Markdown (block), and PHP. Introduce `LanguageSupport` + `get_language_by_name` so injected language names (with common aliases like `ts`→typescript, `scss`→css) resolve through one canonical table.
- Recursion is capped at depth 4; unbundled injected languages silently fall back to plain text.

## Behavior impact
- Astro frontmatter + `{expr}` + `<style>` / `<script>` now syntax-highlighted.
- Svelte `<script lang="ts">` / `<style>` now highlighted.
- HTML `<script>` / `<style>` bodies now highlighted.
- Markdown fenced code blocks now highlighted per language.
- PHP embedded HTML now highlighted.

## Out of scope (follow-ups)
- `#set! injection.combined` — each injection parsed independently.
- Markdown inline backtick injections (`INJECTION_QUERY_INLINE` not wired).
- Injection targets not bundled (e.g. `phpdoc`, `pug`).

## Test plan
- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (17 passed)
- [x] `cargo run --example test_highlighter` — confirmed inner-language tokens appear for Markdown `\`\`\`rust`, Astro frontmatter + `{name}` + `<style>`, HTML `<style>` body.
- [ ] Manual smoke test via `cargo run` on a repo containing `.astro`/`.svelte`/`.md`/`.html`/`.php` diffs — eyeball editor pane.

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add lookup-by-name for languages and expanded aliases (e.g., shell, c#, postcss, golang, json5).
  * Improved handling of embedded and nested language highlighting (Astro, HTML, Markdown, PHP, Svelte).

* **Tests**
  * Added end-to-end highlighting tests for Astro and HTML snippets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->