### PR TITLE
docs(readme): add splashboard-style hero section with badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
-# gitlogue
-
-<a title="This tool is Tool of The Week on Terminal Trove, The $HOME of all things in the terminal" href="https://terminaltrove.com/gitlogue/"><img src="https://cdn.terminaltrove.com/media/badges/tool_of_the_week/svg/terminal_trove_tool_of_the_week_green_on_black_bg.svg" alt="Terminal Trove Tool of The Week" height="48" /></a>
-
 <p align="center">
-  <img src="docs/assets/demo.gif" alt="gitlogue demo" style="max-width: 100%; width: 800px;" />
+  <img src="docs/assets/demo.gif" alt="gitlogue" width="820">
 </p>
 
-A cinematic Git commit replay tool for the terminal, turning your Git history into a living, animated story.
+<p align="center">
+  <a href="https://crates.io/crates/gitlogue"><img src="https://img.shields.io/crates/v/gitlogue.svg?style=flat-square&color=E06B4B" alt="crates.io"></a>
+  <a href="https://github.com/unhappychoice/gitlogue/releases"><img src="https://img.shields.io/github/v/release/unhappychoice/gitlogue?style=flat-square&color=E0C14B&label=release" alt="release"></a>
+  <a href="https://github.com/unhappychoice/gitlogue/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/unhappychoice/gitlogue/ci.yml?branch=main&style=flat-square&label=CI" alt="CI"></a>
+  <a href="https://github.com/unhappychoice/gitlogue/blob/main/LICENSE"><img src="https://img.shields.io/crates/l/gitlogue.svg?style=flat-square" alt="license"></a>
+  <a href="https://terminaltrove.com/gitlogue/"><img src="https://img.shields.io/badge/Terminal_Trove-Tool_of_The_Week-2ea043?style=flat-square" alt="Terminal Trove Tool of The Week"></a>
+</p>
+
+<p align="center">
+  <strong>A cinematic Git commit replay tool for the terminal.</strong><br>
+  <sub>Turn your Git history into a living, animated story — typing, syntax highlighting, file tree transitions.</sub>
+</p>
 
 Watch commits unfold with realistic typing animations, syntax highlighting, and file tree transitions, transforming code changes into a visual experience.
 


### PR DESCRIPTION
## Summary
- Restructures the top of `README.md` to follow the layout used in [splashboard](https://github.com/unhappychoice/splashboard): a centered hero image, a centered badge row, and a centered tagline + sub-line.
- Badges added: crates.io version, latest GitHub release, CI status, license, and the existing Terminal Trove "Tool of The Week" recognition (re-rendered as a flat-square shield so it sits in line with the rest).
- Drops the bare `# gitlogue` H1 in favor of the hero block, matching the sibling project's visual hierarchy.

## Test plan
- [ ] Render the README on github.com/unhappychoice/gitlogue (PR preview) and confirm the hero image, badge row, and tagline render centered on desktop and reasonably on mobile.
- [ ] Click each badge and confirm it links to the correct destination (crates.io page, releases tab, CI workflow runs, LICENSE file, Terminal Trove award page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved README presentation with a centered demo image and status badges (version, release, CI status, license).
  * Enhanced project description to highlight key features: typing animation, syntax highlighting, and file tree transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->