### PR TITLE
ci: add codecov coverage measurement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,28 @@ jobs:
           prefix-key: v1-rust
       - run: cargo test
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate coverage report
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: false
+
   build:
     name: Build
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,17 +44,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: v1-rust
-      - run: cargo test
-
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   <a href="https://crates.io/crates/gitlogue"><img src="https://img.shields.io/crates/v/gitlogue.svg?style=flat-square&color=E06B4B" alt="crates.io"></a>
   <a href="https://github.com/unhappychoice/gitlogue/releases"><img src="https://img.shields.io/github/v/release/unhappychoice/gitlogue?style=flat-square&color=E0C14B&label=release" alt="release"></a>
   <a href="https://github.com/unhappychoice/gitlogue/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/unhappychoice/gitlogue/ci.yml?branch=main&style=flat-square&label=CI" alt="CI"></a>
+  <a href="https://codecov.io/gh/unhappychoice/gitlogue"><img src="https://img.shields.io/codecov/c/github/unhappychoice/gitlogue?style=flat-square" alt="codecov"></a>
   <a href="https://github.com/unhappychoice/gitlogue/blob/main/LICENSE"><img src="https://img.shields.io/crates/l/gitlogue.svg?style=flat-square" alt="license"></a>
   <a href="https://terminaltrove.com/gitlogue/"><img src="https://img.shields.io/badge/Terminal_Trove-Tool_of_The_Week-2ea043?style=flat-square" alt="Terminal Trove Tool of The Week"></a>
 </p>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+
+ignore:
+  - "tests/"
+  - "examples/"
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary
- Add a `coverage` job to `.github/workflows/ci.yml` using `cargo-llvm-cov` and upload lcov reports via `codecov-action@v3`
- Add `codecov.yml` with project/patch targets at 80% (threshold 1%), ignoring `tests/` and `examples/`
- Add a Codecov badge to the README badge row

This mirrors the setup already used in [gittype](https://github.com/unhappychoice/gittype).

## Test plan
- [ ] CI `Coverage` job passes on this PR
- [ ] Codecov receives the upload and shows the project page
- [ ] README badge renders correctly after merge

## Follow-up
- Register `unhappychoice/gitlogue` on Codecov and (optionally) add `CODECOV_TOKEN` to repo secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established automated code coverage generation and tracking within the continuous integration pipeline to systematically monitor code quality metrics
  * Configured code coverage targets and quality thresholds to maintain code standards
  * Integrated coverage status visibility in project documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->