### PR TITLE
docs: add Support section with star and share links

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,9 +231,9 @@ ISC License. See [LICENSE](LICENSE) for details.
 If you find this project useful, please consider:
 
 - ⭐️ [Star on GitHub](https://github.com/unhappychoice/gitlogue)
-- 🐦 [Share on X](https://x.com/intent/post?text=Your%20Git%20history%20as%20cinema.%20gitlogue%20replays%20commits%20as%20a%20terminal%20animation%20%F0%9F%8E%9E%EF%B8%8F&url=https%3A//github.com/unhappychoice/gitlogue&hashtags=gitlogue)
-- 🦋 [Share on Bluesky](https://bsky.app/intent/compose?text=Your%20Git%20history%20as%20cinema.%20gitlogue%20replays%20commits%20as%20a%20terminal%20animation%20%F0%9F%8E%9E%EF%B8%8F%20%23gitlogue%20https%3A//github.com/unhappychoice/gitlogue)
-- 🧵 [Share on Threads](https://www.threads.net/intent/post?text=Your%20Git%20history%20as%20cinema.%20gitlogue%20replays%20commits%20as%20a%20terminal%20animation%20%F0%9F%8E%9E%EF%B8%8F%20%23gitlogue%20https%3A//github.com/unhappychoice/gitlogue)
+- 🐦 [Share on X](https://x.com/intent/post?text=Your%20Git%20history%20as%20cinema.%20gitlogue%20replays%20commits%20as%20a%20terminal%20animation%20%F0%9F%8E%9E%EF%B8%8F&url=https%3A//github.com/unhappychoice/gitlogue&hashtags=gitlogue,CLI,Rust,git)
+- 🦋 [Share on Bluesky](https://bsky.app/intent/compose?text=Your%20Git%20history%20as%20cinema.%20gitlogue%20replays%20commits%20as%20a%20terminal%20animation%20%F0%9F%8E%9E%EF%B8%8F%20%23gitlogue%20%23CLI%20%23Rust%20%23git%20https%3A//github.com/unhappychoice/gitlogue)
+- 🧵 [Share on Threads](https://www.threads.net/intent/post?text=Your%20Git%20history%20as%20cinema.%20gitlogue%20replays%20commits%20as%20a%20terminal%20animation%20%F0%9F%8E%9E%EF%B8%8F%20%23gitlogue%20%23CLI%20%23Rust%20%23git%20https%3A//github.com/unhappychoice/gitlogue)
 - 💼 [Share on LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A//github.com/unhappychoice/gitlogue)
 - 📘 [Share on Facebook](https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/unhappychoice/gitlogue)
 - 🟧 [Submit to Hacker News](https://news.ycombinator.com/submitlink?u=https%3A//github.com/unhappychoice/gitlogue&t=Your%20Git%20history%20as%20cinema.%20gitlogue%20replays%20commits%20as%20a%20terminal%20animation%20%F0%9F%8E%9E%EF%B8%8F)

--- a/README.md
+++ b/README.md
@@ -237,5 +237,7 @@ If you find this project useful, please consider:
 - 💼 [Share on LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A//github.com/unhappychoice/gitlogue)
 - 📘 [Share on Facebook](https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/unhappychoice/gitlogue)
 - 🟧 [Submit to Hacker News](https://news.ycombinator.com/submitlink?u=https%3A//github.com/unhappychoice/gitlogue&t=Your%20Git%20history%20as%20cinema.%20gitlogue%20replays%20commits%20as%20a%20terminal%20animation%20%F0%9F%8E%9E%EF%B8%8F)
+- 💬 Drop it into your Discord server or developer chat
+- ✍️ Write about it on your blog or in a newsletter
 
 Every bit of support helps. Thanks!

--- a/README.md
+++ b/README.md
@@ -225,3 +225,17 @@ ISC License. See [LICENSE](LICENSE) for details.
 ## Author
 
 [@unhappychoice](https://unhappychoice.com)
+
+## Support
+
+If you find this project useful, please consider:
+
+- ⭐️ [Star on GitHub](https://github.com/unhappychoice/gitlogue)
+- 🐦 [Share on X](https://x.com/intent/post?text=Your%20Git%20history%20as%20cinema.%20gitlogue%20replays%20commits%20as%20a%20terminal%20animation%20%F0%9F%8E%9E%EF%B8%8F&url=https%3A//github.com/unhappychoice/gitlogue&hashtags=gitlogue)
+- 🦋 [Share on Bluesky](https://bsky.app/intent/compose?text=Your%20Git%20history%20as%20cinema.%20gitlogue%20replays%20commits%20as%20a%20terminal%20animation%20%F0%9F%8E%9E%EF%B8%8F%20%23gitlogue%20https%3A//github.com/unhappychoice/gitlogue)
+- 🧵 [Share on Threads](https://www.threads.net/intent/post?text=Your%20Git%20history%20as%20cinema.%20gitlogue%20replays%20commits%20as%20a%20terminal%20animation%20%F0%9F%8E%9E%EF%B8%8F%20%23gitlogue%20https%3A//github.com/unhappychoice/gitlogue)
+- 💼 [Share on LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A//github.com/unhappychoice/gitlogue)
+- 📘 [Share on Facebook](https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/unhappychoice/gitlogue)
+- 🟧 [Submit to Hacker News](https://news.ycombinator.com/submitlink?u=https%3A//github.com/unhappychoice/gitlogue&t=Your%20Git%20history%20as%20cinema.%20gitlogue%20replays%20commits%20as%20a%20terminal%20animation%20%F0%9F%8E%9E%EF%B8%8F)
+
+Every bit of support helps. Thanks!


### PR DESCRIPTION
## Summary

- Add a Support section at the end of README with links to star the repo and share it on X, Bluesky, Threads, LinkedIn, Facebook, and Hacker News.
- Each share link is pre-filled with a short pitch and the `#gitlogue` hashtag where supported.

## Test plan

- [x] README renders correctly on GitHub
- [ ] Each share link opens the target platform's composer with the expected text and URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README with a new "Support" section encouraging readers to star and share the project across social platforms (X, Bluesky, Threads, LinkedIn, Facebook, Hacker News), plus links/prompts for Discord/developer chat and blog/newsletter, and a closing thank-you message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/gitlogue/pull/205)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->