### PR TITLE
fix(ci): bump cachix/install-nix-action from v27 to v31

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v31
       - name: Build unstable package
         run: nix build .#unstable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         run: cargo test
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31
 
       - name: Update flake.nix
         run: |
@@ -202,7 +202,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v31
 
       - name: Calculate and update hashes
         run: |


### PR DESCRIPTION
## Summary
- The Nix Build CI job has been failing on dependabot PRs (e.g. #209) when fetching crates from crates.io, with errors like:
  ```
  curl: (22) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
  curl: (22) The requested URL returned error: 403
  error: cannot download crate-ctrlc-3.5.2.tar.gz from any mirror
  ```
- Root cause: `cachix/install-nix-action@v27` ships Nix 2.26.3, which mishandles the `crates.io` → `static.crates.io` redirect for newer crates not yet cached in nixpkgs.
- Fix: bump the action to `v31` (Nix 2.34.7), which corrects the fetch behavior.

## Test plan
- [ ] Nix Build job passes on this PR
- [ ] Re-run CI on #209 (or other open dependabot PRs) and confirm Nix Build no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows: replaced the build/release workflow step with a newer installer action to improve build reproducibility and release job stability across multiple workflow jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->