### PR TITLE
chore(nix): update nixpkgs to fix crate downloads

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763835633,
-        "narHash": "sha256-HzxeGVID5MChuCPESuC0dlQL1/scDKu+MmzoVBJxulM=",
+        "lastModified": 1787900134,
+        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "050e09e091117c3d7328c7b2b7b577492c43c134",
+        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Problem

`Nix Build` CI is failing on every branch (e.g. #232):

```
trying https://crates.io/api/v1/crates/scanlex/0.2.0/download
curl: (22) The requested URL returned error: 403
error: cannot download crate-scanlex-0.2.0.tar.gz from any mirror
```

crates.io now rejects the `/api/v1/crates/<name>/<version>/download` endpoint (403 for any crate), and the pinned nixpkgs (`050e09e`, 2025-11-22) uses exactly that URL in `import-cargo-lock.nix`. Any `nix build .#unstable` fails as soon as a crate is not already in the binary cache — `scanlex` was simply the first one to need a real download after the chrono-english 0.2.0 bump.

This is unrelated to the branches it happens to break; `main` fails the same way today.

## Fix

Bump the nixpkgs pin (`050e09e` 2025-11-22 → `83199d0` 2026-08-28). Newer nixpkgs fetches crates from `static.crates.io` instead, per rust-lang/crates.io#13482.

## Verification

- `https://static.crates.io/crates/scanlex/0.2.0/download` → 200 (vs 403 on the API endpoint)
- `nix build .#unstable` succeeds locally with the updated lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)