### PR TITLE
fix(ci): fail Homebrew SHA step on HTTP errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,19 +255,25 @@ jobs:
 
       - name: Update Homebrew formula
         run: |
+          set -euo pipefail
+
+          fetch_sha() {
+            curl -fsSL --retry 3 --retry-delay 5 "$1" | sha256sum | cut -d' ' -f1
+          }
+
           VERSION=${{ needs.release.outputs.new_version }}
 
           MACOS_INTEL_URL="https://github.com/unhappychoice/gitlogue/releases/download/$VERSION/gitlogue-$VERSION-x86_64-apple-darwin.tar.gz"
-          MACOS_INTEL_SHA=$(curl -sL "$MACOS_INTEL_URL" | sha256sum | cut -d' ' -f1)
+          MACOS_INTEL_SHA=$(fetch_sha "$MACOS_INTEL_URL")
 
           MACOS_ARM_URL="https://github.com/unhappychoice/gitlogue/releases/download/$VERSION/gitlogue-$VERSION-aarch64-apple-darwin.tar.gz"
-          MACOS_ARM_SHA=$(curl -sL "$MACOS_ARM_URL" | sha256sum | cut -d' ' -f1)
+          MACOS_ARM_SHA=$(fetch_sha "$MACOS_ARM_URL")
 
           LINUX_INTEL_URL="https://github.com/unhappychoice/gitlogue/releases/download/$VERSION/gitlogue-$VERSION-x86_64-unknown-linux-gnu.tar.gz"
-          LINUX_INTEL_SHA=$(curl -sL "$LINUX_INTEL_URL" | sha256sum | cut -d' ' -f1)
+          LINUX_INTEL_SHA=$(fetch_sha "$LINUX_INTEL_URL")
 
           LINUX_ARM_URL="https://github.com/unhappychoice/gitlogue/releases/download/$VERSION/gitlogue-$VERSION-aarch64-unknown-linux-gnu.tar.gz"
-          LINUX_ARM_SHA=$(curl -sL "$LINUX_ARM_URL" | sha256sum | cut -d' ' -f1)
+          LINUX_ARM_SHA=$(fetch_sha "$LINUX_ARM_URL")
 
           echo "Calculated SHAs:"
           echo "macOS Intel: $MACOS_INTEL_SHA"


### PR DESCRIPTION
## Summary

`curl -sL "$URL" | sha256sum` exits 0 on a 404, so `sha256sum` digested the error body and the Homebrew formula got a bogus SHA while the job stayed green.

- Extract a `fetch_sha` helper using `curl -fsSL --retry 3 --retry-delay 5`
- Add `set -euo pipefail` so a failed `curl` in the pipeline aborts the step

## Verification

Ran the helper locally:

- Nonexistent asset URL -> `curl: (22) ... 404`, script exits 22 before assigning a SHA
- Real `v0.11.0` linux-gnu asset -> `ff58adcdbbd5474d5bcabe8194313574aab967a60bfc1757070ba025ff9379c4`, exit 0

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation reliability by detecting failed asset downloads instead of silently generating invalid checksums.
  * Added automatic retries for temporary download failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->